### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -8,11 +8,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install fonts
         run: sudo apt-get install fonts-font-awesome fonts-roboto texlive-fonts-recommended texlive-fonts-extra
-      - name: Typst
-        uses: yusancky/setup-typst@v2
-        id: setup-typst
+      - name: Setup Typst
+        uses: typst-community/setup-typst@v4
         with:
-          version: 'v0.11.0'
+          typst-version: 'v0.11.0'
       - run: typst compile modern-cv-docs.typ
       - name: Upload PDF file
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Bump **[`typst-community/setup-typst`](https://github.com/typst-community/setup-typst)** to v4

> [!WARNING] 
> The action `yusancky/setup-typst` has officially been **migrated** to repository `typst-community/setup-typst`. See [announcement](https://gist.github.com/yusancky/b676f56d40d6346dfc67ed477ca2ea1a) for more information.