### PR TITLE
Bump Upload Artifact to v4

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -15,7 +15,7 @@ jobs:
           version: 'v0.11.0'
       - run: typst compile modern-cv-docs.typ
       - name: Upload PDF file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: modern-cv-docs
           path: modern-cv-docs.pdf


### PR DESCRIPTION
> [!WARNING]
> `actions/upload-artifact@v3` was deprecated on November 30, 2024. [Learn More](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)